### PR TITLE
ENH: Adding code to use clutter field to add a clutter id to gate id.

### DIFF
--- a/cmac/cmac_quicklooks.py
+++ b/cmac/cmac_quicklooks.py
@@ -68,8 +68,9 @@ def quicklooks(radar, image_directory=None, sweep=3,
                   'multi_trip': 'red',
                   'no_scatter': 'gray',
                   'snow': 'cyan',
-                  'melting': 'yellow'}
-    lab_colors = ['red', 'cyan', 'grey', 'green', 'yellow']
+                  'melting': 'yellow',
+                  'clutter': 'black'}
+    lab_colors = ['red', 'cyan', 'grey', 'green', 'yellow', 'black']
     lab_colors = [cat_colors[kitty[0]] for kitty in sorted_cats]
     cmap = matplotlib.colors.ListedColormap(lab_colors)
 
@@ -81,7 +82,7 @@ def quicklooks(radar, image_directory=None, sweep=3,
                          max_lat=max_lat, resolution='l', cmap=cmap,
                          vmin=0, vmax=5)
     cbax = plt.gca()
-    tick_locs = np.linspace(0, len(sorted_cats) - 1, len(sorted_cats)) + 0.5
+    tick_locs = np.linspace(0, len(sorted_cats) - 2, len(sorted_cats)) + 0.5
     display.cbs[-1].locator = matplotlib.ticker.FixedLocator(tick_locs)
     catty_list = [sorted_cats[i][0] for i in range(len(sorted_cats))]
     display.cbs[-1].formatter = matplotlib.ticker.FixedFormatter(catty_list)

--- a/cmac/cmac_xsapr.py
+++ b/cmac/cmac_xsapr.py
@@ -12,7 +12,8 @@ import numpy as np
 from . import processing_code
 
 
-def cmac(radar, sonde, alt=320.0, attenuation_a_coef=None, **kwargs):
+def cmac(radar, sonde, clutter_field, alt=320.0, attenuation_a_coef=None,
+         **kwargs):
     """
     Corrected Moments in Antenna Coordinates
 
@@ -22,6 +23,8 @@ def cmac(radar, sonde, alt=320.0, attenuation_a_coef=None, **kwargs):
         Radar object to use in the CMAC calculation.
     sonde : Object
         Object containing all the sonde data.
+    clutter_field : array
+        Array with xsapr_clutter field data for addition of clutter gate id.
 
     Other Parameters
     ----------------
@@ -64,6 +67,10 @@ def cmac(radar, sonde, alt=320.0, attenuation_a_coef=None, **kwargs):
     my_fuzz, cats = processing_code.do_my_fuzz(radar, **kwargs)
     radar.add_field('gate_id', my_fuzz,
                     replace_existing=True)
+    radar.fields['gate_id']['data'][clutter_field == 1] = 5
+    notes = radar.fields['gate_id']['notes']
+    radar.fields['gate_id']['notes'] = notes + ',5:clutter'
+    radar.fields['gate_id']['valid_max'] = 5
     cat_dict = {}
     for pair_str in radar.fields['gate_id']['notes'].split(','):
         cat_dict.update(

--- a/environment.yml
+++ b/environment.yml
@@ -111,6 +111,7 @@ dependencies:
   - decorator==4.1.1
   - networkx==1.11
   - scikit-fuzzy==0.3
+  - git+https://github.com/zssherman/xsapr_clutter_project.git
   - git+https://github.com/ARM-DOE/pyart.git
   - git+https://github.com/EVS-ATMOS/cmac2.0.git
   - git+https://github.com/CSU-Radarmet/CSU_RadarTools.git

--- a/scripts/xsapr_cmac
+++ b/scripts/xsapr_cmac
@@ -83,8 +83,9 @@ def main():
     print('## CMAC 2.0 Completed')
 
     del radar
-    del clutter_radar
     del sonde
+    del clutter_radar
+    del cmac_radar
 
 if __name__ == '__main__':
     main()

--- a/scripts/xsapr_cmac
+++ b/scripts/xsapr_cmac
@@ -22,6 +22,9 @@ def main():
         'sonde_file', type=str,
         help='Sonde file to use for CMAC calculation.')
     parser.add_argument(
+        'clutter_file', type=str,
+        help='clutter file to use for addition of clutter gate id.')
+    parser.add_argument(
         '-o', '--out_radar', type=str, default=None,
         help=('Out file path and name to use for the CMAC radar.'
               + ' If not provided, radar is written to users home'
@@ -52,9 +55,11 @@ def main():
     args = parser.parse_args()
 
     radar = pyart.io.read(args.radar_file)
+    clutter_radar = pyart.io.read(args.clutter_file)
     sonde = netCDF4.Dataset(args.sonde_file)
+    clutter_field = clutter_radar.fields['xsapr_clutter']['data']
 
-    cmac_radar = cmac(radar, sonde, alt=args.altitude)
+    cmac_radar = cmac(radar, sonde, clutter_field, alt=args.altitude)
     if args.out_radar is None:
         pyart.io.write_cfradial(
             os.path.expanduser('~')+'/cmac_radar.nc', cmac_radar)
@@ -76,6 +81,10 @@ def main():
         print('## Quicklooks have been save to ' + args.image_directory)
     print('##')
     print('## CMAC 2.0 Completed')
+
+    del radar
+    del clutter_radar
+    del sonde
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Code takes a clutter file then uses the clutter_radar's clutter field and feeds it into cmac_xsapr. The gate id is then updated to have clutter as gate id 5. Quicklooks have been updated to have the added color and correct tick placement. Added some del objects to save memory for xsapr_cmac script.