### PR TITLE
ENH: Configuration file depending on which radar.

### DIFF
--- a/cmac/__init__.py
+++ b/cmac/__init__.py
@@ -11,6 +11,9 @@ Functions
 .. autosummary::
     :toctree: generated/
 
+    CONFIG_XSAPR_I4
+    CONFIG_XSAPR_I5
+    CONFIG_XSAPR_I6
     cmac
     quicklooks
     snr_and_sounding
@@ -23,6 +26,7 @@ Functions
 
 """
 
+from .config import CONFIG_XSAPR_I4, CONFIG_XSAPR_I5, CONFIG_XSAPR_I6
 from .cmac_xsapr import cmac
 from .cmac_quicklooks import quicklooks
 from .processing_code import snr_and_sounding, do_my_fuzz

--- a/cmac/__init__.py
+++ b/cmac/__init__.py
@@ -11,9 +11,9 @@ Functions
 .. autosummary::
     :toctree: generated/
 
-    CONFIG_XSAPR_I4
-    CONFIG_XSAPR_I5
-    CONFIG_XSAPR_I6
+    config_xsapr_i4
+    config_xsapr_i5
+    config_xsapr_i6
     cmac
     quicklooks
     snr_and_sounding
@@ -26,7 +26,7 @@ Functions
 
 """
 
-from .config import CONFIG_XSAPR_I4, CONFIG_XSAPR_I5, CONFIG_XSAPR_I6
+from .config import config_xsapr_i4, config_xsapr_i5, config_xsapr_i6
 from .cmac_xsapr import cmac
 from .cmac_quicklooks import quicklooks
 from .processing_code import snr_and_sounding, do_my_fuzz

--- a/cmac/cmac_quicklooks.py
+++ b/cmac/cmac_quicklooks.py
@@ -17,9 +17,11 @@ from pyart.graph.common import generate_radar_time_begin
 plt.switch_backend('agg')
 
 
-def quicklooks(radar, image_directory=None, sweep=3,
+def quicklooks(radar, facility_id, image_directory=None, sweep=3,
                max_lat=37.0, min_lat=36.0, max_lon=-97.0, min_lon=-98.3,
-               dd_lobes=True):
+               dd_lobes=True, dd_lobes_radar1_lon=None,
+               dd_lobes_radar1_lat=None, dd_lobes_radar2_lon=None,
+               dd_lobes_radar2_lat=None):
     """
     Quicklooks, images produced with regards to CMAC
 
@@ -27,6 +29,8 @@ def quicklooks(radar, image_directory=None, sweep=3,
     ---------
     radar : Radar
         Radar object that has CMAC applied to it.
+    facility_id : String
+        String stating the id of the radar. For example: 'I5'.
 
     Optional Parameters
     -------------------
@@ -44,7 +48,23 @@ def quicklooks(radar, image_directory=None, sweep=3,
     min_lon : float
         Minimum longitude for plot bounds. Default is -98.3.
     dd_lobes : bool
-        Plot DD lobes between i4 and i5 if = True.
+        Plot DD lobes between radars if dd_lobes is True.
+    dd_lobes_radar1_lon : Tuple
+        Values in degrees of the longitude coordinates for the main radar
+        being plotted for the dd_lobes_calculation. If dd_lobes argument is
+        False, dd_lobes_radar1 and dd_lobes_radar2 are not used.
+    dd_lobes_radar1_lat : Tuple
+        Values in degrees of the latitude coordinates for the main radar
+        being plotted for the dd_lobes_calculation. If dd_lobes argument is
+        False, dd_lobes_radar1 and dd_lobes_radar2 are not used.
+    dd_lobes_radar2_lon : Tuple
+        Values in degrees of the longitude coordinates for the secondary radar
+        within the plot for the dd_lobes_calculation. If dd_lobes argument
+        is False, dd_lobes_radar1 and dd_lobes_radar2 are not used.
+    dd_lobes_radar2_lat : Tuple
+        Values in degrees of the latitude coordinates for the secondary radar
+        within the plot for the dd_lobes_calculation. If dd_lobes argument
+        is False, dd_lobes_radar1 and dd_lobes_radar2 are not used.
 
     """
 
@@ -55,18 +75,24 @@ def quicklooks(radar, image_directory=None, sweep=3,
         radar.time['data'][0], radar.time['units'])
 
     date_string = datetime.strftime(radar_start_date, '%Y%m%d.%H%M%S')
-    arm_name = '.sgpxsaprcmacsurI5.c1.'
+    arm_name = '.sgpxsaprcmacsur' + facility_id + '.c1.'
     combined_name = arm_name + date_string
 
     # Creating a plot of reflectivity before CMAC.
     lal = np.arange(min_lat, max_lat+.2, .2)
     lol = np.arange(min_lon, max_lon+.2, .2)
-    grid_lat = np.arange(min_lat, max_lat, 0.01)
-    grid_lon = np.arange(min_lon, max_lon, 0.01)
-    i5 = [_dms_to_decimal(-97, 35, 37.68), _dms_to_decimal(36, 29, 29.4)]
-    i4 = [_dms_to_decimal(-97, 21, 49.32), _dms_to_decimal(36, 34, 44.4)]
-    bca = _get_bca(i4[0], i4[1], i5[0], i5[1], grid_lon, grid_lat)
-    grid_lon, grid_lat = np.meshgrid(grid_lon, grid_lat)
+
+    if dd_lobes is True:
+        grid_lat = np.arange(min_lat, max_lat, 0.01)
+        grid_lon = np.arange(min_lon, max_lon, 0.01)
+        dms_radar1 = [_dms_to_decimal(dd_lobes_radar1_lon),
+                      _dms_to_decimal(dd_lobes_radar1_lat)]
+        dms_radar2 = [_dms_to_decimal(dd_lobes_radar2_lon),
+                      _dms_to_decimal(dd_lobes_radar2_lat)]
+
+        bca = _get_bca(dms_radar2[0], dms_radar2[1], dms_radar1[0],
+                       dms_radar1[1], grid_lon, grid_lat)
+        grid_lon, grid_lat = np.meshgrid(grid_lon, grid_lat)
 
     display = pyart.graph.RadarMapDisplayCartopy(radar)
     fig = plt.figure(figsize=[12, 8])

--- a/cmac/cmac_quicklooks.py
+++ b/cmac/cmac_quicklooks.py
@@ -19,9 +19,8 @@ plt.switch_backend('agg')
 
 def quicklooks(radar, facility_id, image_directory=None, sweep=3,
                max_lat=37.0, min_lat=36.0, max_lon=-97.0, min_lon=-98.3,
-               dd_lobes=True, dd_lobes_radar1_lon=None,
-               dd_lobes_radar1_lat=None, dd_lobes_radar2_lon=None,
-               dd_lobes_radar2_lat=None):
+               dd_lobes=True, dms_radar1_coords=None,
+               dms_radar2_coords=None):
     """
     Quicklooks, images produced with regards to CMAC
 
@@ -49,22 +48,14 @@ def quicklooks(radar, facility_id, image_directory=None, sweep=3,
         Minimum longitude for plot bounds. Default is -98.3.
     dd_lobes : bool
         Plot DD lobes between radars if dd_lobes is True.
-    dd_lobes_radar1_lon : Tuple
-        Values in degrees of the longitude coordinates for the main radar
-        being plotted for the dd_lobes_calculation. If dd_lobes argument is
-        False, dd_lobes_radar1 and dd_lobes_radar2 are not used.
-    dd_lobes_radar1_lat : Tuple
-        Values in degrees of the latitude coordinates for the main radar
-        being plotted for the dd_lobes_calculation. If dd_lobes argument is
-        False, dd_lobes_radar1 and dd_lobes_radar2 are not used.
-    dd_lobes_radar2_lon : Tuple
-        Values in degrees of the longitude coordinates for the secondary radar
-        within the plot for the dd_lobes_calculation. If dd_lobes argument
-        is False, dd_lobes_radar1 and dd_lobes_radar2 are not used.
-    dd_lobes_radar2_lat : Tuple
-        Values in degrees of the latitude coordinates for the secondary radar
-        within the plot for the dd_lobes_calculation. If dd_lobes argument
-        is False, dd_lobes_radar1 and dd_lobes_radar2 are not used.
+    dms_radar1_coords : List
+        Values in degrees of the longitude and latitude coordinates for the
+        main radar being plotted for the dd_lobes_calculation. If dd_lobes
+        argument is False, dms_radar1_coords is not used.
+    dms_radar2_coords : List
+        Values in degrees of the longitude and latitude coordinates for the
+        secondary radar within the plot for the dd_lobes_calculation. If
+        dd_lobes argument is False, dms_radar2_coords is not used.
 
     """
 
@@ -85,20 +76,19 @@ def quicklooks(radar, facility_id, image_directory=None, sweep=3,
     if dd_lobes is True:
         grid_lat = np.arange(min_lat, max_lat, 0.01)
         grid_lon = np.arange(min_lon, max_lon, 0.01)
-        dms_radar1 = [_dms_to_decimal(
-            dd_lobes_radar1_lon[0], dd_lobes_radar1_lon[1],
-            dd_lobes_radar1_lon[2]), _dms_to_decimal(
-                dd_lobes_radar1_lat[0], dd_lobes_radar1_lat[1],
-                dd_lobes_radar1_lat[2])]
-        dms_radar2 = [_dms_to_decimal(
-            dd_lobes_radar2_lon[0], dd_lobes_radar2_lon[1],
-            dd_lobes_radar2_lon[2]), _dms_to_decimal(
-                dd_lobes_radar2_lat[0], dd_lobes_radar2_lat[1],
-                dd_lobes_radar2_lat[2])]
+        dec_radar1 = [_dms_to_decimal(
+            dms_radar1_coords[0][0], dms_radar1_coords[0][1],
+            dms_radar1_coords[0][2]), _dms_to_decimal(
+                dms_radar1_coords[1][0], dms_radar1_coords[1][1],
+                dms_radar1_coords[1][2])]
+        dec_radar2 = [_dms_to_decimal(
+            dms_radar2_coords[0][0], dms_radar2_coords[0][1],
+            dms_radar2_coords[0][2]), _dms_to_decimal(
+                dms_radar2_coords[1][0], dms_radar2_coords[1][1],
+                dms_radar2_coords[1][2])]
 
-
-        bca = _get_bca(dms_radar2[0], dms_radar2[1], dms_radar1[0],
-                       dms_radar1[1], grid_lon, grid_lat)
+        bca = _get_bca(dec_radar2[0], dec_radar2[1], dec_radar1[0],
+                       dec_radar1[1], grid_lon, grid_lat)
         grid_lon, grid_lat = np.meshgrid(grid_lon, grid_lat)
 
     display = pyart.graph.RadarMapDisplayCartopy(radar)

--- a/cmac/cmac_quicklooks.py
+++ b/cmac/cmac_quicklooks.py
@@ -85,10 +85,17 @@ def quicklooks(radar, facility_id, image_directory=None, sweep=3,
     if dd_lobes is True:
         grid_lat = np.arange(min_lat, max_lat, 0.01)
         grid_lon = np.arange(min_lon, max_lon, 0.01)
-        dms_radar1 = [_dms_to_decimal(dd_lobes_radar1_lon),
-                      _dms_to_decimal(dd_lobes_radar1_lat)]
-        dms_radar2 = [_dms_to_decimal(dd_lobes_radar2_lon),
-                      _dms_to_decimal(dd_lobes_radar2_lat)]
+        dms_radar1 = [_dms_to_decimal(
+            dd_lobes_radar1_lon[0], dd_lobes_radar1_lon[1],
+            dd_lobes_radar1_lon[2]), _dms_to_decimal(
+                dd_lobes_radar1_lat[0], dd_lobes_radar1_lat[1],
+                dd_lobes_radar1_lat[2])]
+        dms_radar2 = [_dms_to_decimal(
+            dd_lobes_radar2_lon[0], dd_lobes_radar2_lon[1],
+            dd_lobes_radar2_lon[2]), _dms_to_decimal(
+                dd_lobes_radar2_lat[0], dd_lobes_radar2_lat[1],
+                dd_lobes_radar2_lat[2])]
+
 
         bca = _get_bca(dms_radar2[0], dms_radar2[1], dms_radar1[0],
                        dms_radar1[1], grid_lon, grid_lat)

--- a/cmac/cmac_xsapr.py
+++ b/cmac/cmac_xsapr.py
@@ -12,8 +12,8 @@ import numpy as np
 from . import processing_code
 
 
-def cmac(radar, sonde, alt=320.0, attenuation_a_coef=None,
-         meta_append=None):
+def cmac(radar, sonde, facility_id, town, alt,
+         attenuation_a_coef=None, meta_append=None):
     """
     Corrected Moments in Antenna Coordinates
 
@@ -23,11 +23,15 @@ def cmac(radar, sonde, alt=320.0, attenuation_a_coef=None,
         Radar object to use in the CMAC calculation.
     sonde : Object
         Object containing all the sonde data.
+    facility_id : String
+        String stating the id of the radar. For example: 'I5'.
+    town : String
+        String stating the town of the radar. For example: 'Garber, OK'.
+    alt : Float
+        Value to use as default altitude for the radar object.
 
     Other Parameters
     ----------------
-    alt : float
-        Value to use as default altitude for the radar object.
     attenuation_a_coef : float
         A coefficient in attenuation calculation.
     meta_append : dictonary
@@ -42,7 +46,7 @@ def cmac(radar, sonde, alt=320.0, attenuation_a_coef=None,
 
     # Obtaining variables needed for fuzzy logic.
     radar.altitude['data'][0] = alt
-    
+ 
     radar_start_date = netCDF4.num2date(
         radar.time['data'][0], radar.time['units'])
     print('##', str(radar_start_date))
@@ -171,9 +175,10 @@ def cmac(radar, sonde, alt=320.0, attenuation_a_coef=None,
         command_line = ''
         for item in sys.argv:
             command_line = command_line + ' ' + item
+
         meta_append = {
             'site_id': 'sgp',
-            'facility_id': 'i5: Garber, Ok',
+            'facility_id': facility_id + ': ' + town,
             'data_level': 'c1',
             'comment': (
                 'This is highly experimental and initial data. There are many',

--- a/cmac/config.py
+++ b/cmac/config.py
@@ -9,7 +9,7 @@ have to also be changed.
 """
 
 
-CONFIG_XSAPR_I6 = {
+config_xsapr_i6 = {
     'site': 'I6',
     'town': 'Deer Creek, OK',
     'x_compass': 'XNW',
@@ -26,7 +26,7 @@ CONFIG_XSAPR_I6 = {
     'site_i4_dms_lat': (36, 34, 44.4),
     'site_i4_dms_lon': (-97, 21, 49.32)}
 
-CONFIG_XSAPR_I5 = {
+config_xsapr_i5 = {
     'site': 'I5',
     'town': 'Garber, OK',
     'x_compass': 'XSW',
@@ -43,7 +43,7 @@ CONFIG_XSAPR_I5 = {
     'site_i4_dms_lat': (36, 34, 44.4),
     'site_i4_dms_lon': (-97, 21, 49.32)}
 
-CONFIG_XSAPR_I4 = {
+config_xsapr_i4 = {
     'site': 'I4',
     'town': 'Billings, OK',
     'x_compass': 'XSE',

--- a/cmac/config.py
+++ b/cmac/config.py
@@ -1,0 +1,61 @@
+"""
+Configuration file for the Corrected Moments Antenna Coordinates (CMAC2.0).
+
+The values for a number of parameters that change depending on which X-SAPR
+is being used (I4, I5 and I6). Note: If a different type of radar is used,
+values within the kdp, rainrate amd specific attenuation, for example, will
+have to also be changed.
+
+"""
+
+
+CONFIG_XSAPR_I6 = {
+    'site': 'I6',
+    'town': 'Deer Creek, OK',
+    'x_compass': 'XNW',
+    'site_alt': 341,
+    'field_shape': (8280, 501),
+    'max_lat': 37.3,
+    'min_lat': 36.25,
+    'max_lon': -96.9,
+    'min_lon': -98.2,
+    'site_i6_dms_lat': (36, 46, 2.28),
+    'site_i6_dms_lon': (-97, 32, 53.16),
+    'site_i5_dms_lat': (36, 29, 29.4),
+    'site_i5_dms_lon': (-97, 35, 37.68),
+    'site_i4_dms_lat': (36, 34, 44.4),
+    'site_i4_dms_lon': (-97, 21, 49.32)}
+
+CONFIG_XSAPR_I5 = {
+    'site': 'I5',
+    'town': 'Garber, OK',
+    'x_compass': 'XSW',
+    'site_alt': 328,
+    'field_shape': (8680, 501),
+    'max_lat': 37.0,
+    'min_lat': 36.0,
+    'max_lon': -97.0,
+    'min_lon': -98.3,
+    'site_i6_dms_lat': (36, 46, 2.28),
+    'site_i6_dms_lon': (-97, 32, 53.16),
+    'site_i5_dms_lat': (36, 29, 29.4),
+    'site_i5_dms_lon': (-97, 35, 37.68),
+    'site_i4_dms_lat': (36, 34, 44.4),
+    'site_i4_dms_lon': (-97, 21, 49.32)}
+
+CONFIG_XSAPR_I4 = {
+    'site': 'I4',
+    'town': 'Billings, OK',
+    'x_compass': 'XSE',
+    'site_alt': 330,
+    'field_shape': (9200, 501),
+    'max_lat': 37.1,
+    'min_lat': 36.1,
+    'max_lon': -96.7,
+    'min_lon': -98.0,
+    'site_i6_dms_lat': (36, 46, 2.28),
+    'site_i6_dms_lon': (-97, 32, 53.16),
+    'site_i5_dms_lat': (36, 29, 29.4),
+    'site_i5_dms_lon': (-97, 35, 37.68),
+    'site_i4_dms_lat': (36, 34, 44.4),
+    'site_i4_dms_lon': (-97, 21, 49.32)}

--- a/cmac/config.py
+++ b/cmac/config.py
@@ -10,7 +10,7 @@ have to also be changed.
 
 
 config_xsapr_i6 = {
-    'site': 'I6',
+    'facility': 'I6',
     'town': 'Deer Creek, OK',
     'x_compass': 'XNW',
     'site_alt': 341,
@@ -27,7 +27,7 @@ config_xsapr_i6 = {
     'site_i4_dms_lon': (-97, 21, 49.32)}
 
 config_xsapr_i5 = {
-    'site': 'I5',
+    'facility': 'I5',
     'town': 'Garber, OK',
     'x_compass': 'XSW',
     'site_alt': 328,
@@ -44,7 +44,7 @@ config_xsapr_i5 = {
     'site_i4_dms_lon': (-97, 21, 49.32)}
 
 config_xsapr_i4 = {
-    'site': 'I4',
+    'facility': 'I4',
     'town': 'Billings, OK',
     'x_compass': 'XSE',
     'site_alt': 330,

--- a/scripts/gen_clutter_dask
+++ b/scripts/gen_clutter_dask
@@ -24,9 +24,13 @@ def main():
                                       'in the list will be processed.'))
     parser.add_argument(
         'out_file_name', type=str, help=('Output Cf/Radial file'))
+    parser.add_argument(
+        'facility', type=str, help=('Facility ID such as I4, to show which',
+                                    'X-SAPR data is being used.')) 
     args = parser.parse_args()
     if os.path.isdir(args.radar_path):
-        radar_files = glob.glob(args.radar_path + '/**/*XSW*', recursive=True)
+        radar_files = glob.glob(args.radar_path + '/**/*' + args.facility
+                                + '*', recursive=True)
     elif os.path.isfile(args.radar_path):
         with open(args.radar_path) as f:
             radar_files = f.readlines()

--- a/scripts/xsapr_cmac
+++ b/scripts/xsapr_cmac
@@ -51,22 +51,22 @@ def main():
 
     if args.facility == 'I4':
         from cmac import config_xsapr_i4 as radar_config
-        radar1_dms_lon = radar_config['site_i4_dms_lon']
-        radar1_dms_lat = radar_config['site_i4_dms_lat']
-        radar2_dms_lon = radar_config['site_i5_dms_lon']
-        radar2_dms_lat = radar_config['site_i5_dms_lat']
+        dms_radar1_coords = [radar_config['site_i4_dms_lon'],
+                             radar_config['site_i4_dms_lat']]
+        dms_radar2_coords = [radar_config['site_i5_dms_lon'],
+                             radar_config['site_i5_dms_lat']]
     elif args.facility == 'I5':
         from cmac import config_xsapr_i5 as radar_config
-        radar1_dms_lon = radar_config['site_i5_dms_lon']
-        radar1_dms_lat = radar_config['site_i5_dms_lat']
-        radar2_dms_lon = radar_config['site_i4_dms_lon']
-        radar2_dms_lat = radar_config['site_i4_dms_lat']
+        dms_radar1_coords = [radar_config['site_i5_dms_lon'],
+                             radar_config['site_i5_dms_lat']]
+        dms_radar2_coords = [radar_config['site_i4_dms_lon'],
+                             radar_config['site_i4_dms_lat']]
     elif args.facility == 'I6':
         from cmac import config_xsapr_i6 as radar_config
-        radar1_dms_lon = radar_config['site_i6_dms_lon']
-        radar1_dms_lat = radar_config['site_i6_dms_lat']
-        radar2_dms_lon = radar_config['site_i4_dms_lon']
-        radar2_dms_lat = radar_config['site_i4_dms_lat']
+        dms_radar1_coords = [radar_config['site_i6_dms_lon'],
+                             radar_config['site_i6_dms_lat']]
+        dms_radar2_coords = [radar_config['site_i4_dms_lon'],
+                             radar_config['site_i4_dms_lat']]
 
     town = radar_config['town']
     alt = radar_config['site_alt']
@@ -126,10 +126,8 @@ def main():
                sweep=args.sweep, max_lat=max_lat,
                min_lat=min_lat, max_lon=max_lon,
                min_lon=min_lon, dd_lobes=args.dd_lobes,
-               dd_lobes_radar1_lon=radar1_dms_lon,
-               dd_lobes_radar1_lat=radar1_dms_lat,
-               dd_lobes_radar2_lon=radar2_dms_lon,
-               dd_lobes_radar2_lat=radar2_dms_lat)
+               dms_radar1_coords=dms_radar1_coords,
+               dms_radar2_coords=dms_radar2_coords)
 
     del cmac_radar
     print('##')

--- a/scripts/xsapr_cmac
+++ b/scripts/xsapr_cmac
@@ -25,75 +25,112 @@ def main():
         'clutter_file', type=str,
         help='clutter file to use for addition of clutter gate id.')
     parser.add_argument(
-        '-o', '--out_radar', type=str, default=None,
-        help=('Out file path and name to use for the CMAC radar.'
-              + ' If not provided, radar is written to users home'
-              + ' directory.'))
+        'facility', type=str, help=('Facility ID of where the radar that is',
+                                    'being used for CMAC2.0 is located.'))
+    parser.add_argument(
+        '-o', '--out_radar_directory', type=str, default=None,
+        help=('Out file path and name to use for the CMAC radar.',
+              'If not provided, radar is written to users home',
+              'directory.'))
     parser.add_argument(
         '-id', '--image_directory', type=str, default=None,
-        help=('Path to image directory to save CMAC radar images.'
-              + ' If not provided, images are written to users home'
-              + ' directory.'))
-    parser.add_argument(
-        '-alt', '--altitude', type=float, default=320.0,
-        help='Value to use as default altitude for the radar object')
+        help=('Path to image directory to save CMAC radar images.',
+              'If not provided, images are written to users home',
+              'directory.'))
     parser.add_argument(
         '-sw', '--sweep', type=int, default=3,
         help='Value for the sweep to plot.')
-    parser.add_argument(
-        '-maxlat', '--max_latitude', type=float, default=37.0,
-        help='Value to use as max latitude for the bounds of the plots.')
-    parser.add_argument(
-        '-minlat', '--min_latitude', type=float, default=36.0,
-        help='Value to use as min latitude for the bounds of the plots.')
-    parser.add_argument(
-        '-maxlon', '--max_longitude', type=float, default=-97.0,
-        help='Value to use as max longitude for the bounds of the plots.')
-    parser.add_argument(
-        '-minlon', '--min_longitude', type=float, default=-98.3,
-        help='Value to use as min longitude for the bounds of the plots.')
     parser.add_argument('--dd-lobes', dest='dd_lobes', action='store_true',
                         help='Plot Dual Doppler lobes between i4 and i5.')
     parser.add_argument('--no-dd-lobes', dest='dd_lobes', action='store_false',
-                        help=('Do not plot Dual Doppler lobes' + 
-                             ' between i4 and i5.'))
-   
+                        help=('Do not plot Dual Doppler lobes',
+                              'between i4 and i5.'))
+
     parser.set_defaults(dd_lobes=False)
     args = parser.parse_args()
-    
-    
+
+    if args.facility == 'I4':
+        from cmac import config_xsapr_i4 as radar_config
+        radar1_dms_lon = radar_config['site_i4_dms_lon']
+        radar1_dms_lat = radar_config['site_i4_dms_lat']
+        radar2_dms_lon = radar_config['site_i5_dms_lon']
+        radar2_dms_lat = radar_config['site_i5_dms_lat']
+    elif args.facility == 'I5':
+        from cmac import config_xsapr_i5 as radar_config
+        radar1_dms_lon = radar_config['site_i5_dms_lon']
+        radar1_dms_lat = radar_config['site_i5_dms_lat']
+        radar2_dms_lon = radar_config['site_i4_dms_lon']
+        radar2_dms_lat = radar_config['site_i4_dms_lat']
+    elif args.facility == 'I6':
+        from cmac import config_xsapr_i6 as radar_config
+        radar1_dms_lon = radar_config['site_i6_dms_lon']
+        radar1_dms_lat = radar_config['site_i6_dms_lat']
+        radar2_dms_lon = radar_config['site_i4_dms_lon']
+        radar2_dms_lat = radar_config['site_i4_dms_lat']
+
+    town = radar_config['town']
+    alt = radar_config['site_alt']
+    max_lat = radar_config['max_lat']
+    min_lat = radar_config['min_lat']
+    max_lon = radar_config['max_lon']
+    min_lon = radar_config['min_lon']
+
     radar = pyart.io.read(args.radar_file)
     clutter_radar = pyart.io.read(args.clutter_file)
     sonde = netCDF4.Dataset(args.sonde_file)
-    
+
     # Load clutter files.
-    clutter_file_path = args.clutter_file
-    print('## Loading clutter file ' + clutter_file_path)
-    clutter = pyart.io.read(clutter_file_path)
+    print('## Loading clutter file ' + args.clutter_file)
     print('## Reading dictionary...')
-    clutter_field_dict = clutter.fields['xsapr_clutter']
+    clutter_field_dict = clutter_radar.fields['xsapr_clutter']
     print('## Adding clutter field..')
     radar.add_field(
         'xsapr_clutter', clutter_field_dict, replace_existing=True)
-    del clutter
-    cmac_radar = cmac(radar, sonde,  alt=args.altitude)
-    sonde.close()
-    del radar
     del clutter_radar
-    if args.out_radar is None:
-        pyart.io.write_cfradial(
-            os.path.expanduser('~') + '/cmac_radar.nc', cmac_radar)
-        print('## A CMAC radar object has been created at '
-              + os.path.expanduser('~') + '/cmac_radar.nc')
-    else:
-        pyart.io.write_cfradial(args.out_radar, cmac_radar)
-        print('## A CMAC radar object has been created at '
-              + args.out_radar)
 
-    quicklooks(cmac_radar, image_directory=args.image_directory,
-               sweep=args.sweep, max_lat=args.max_latitude,
-               min_lat=args.min_latitude, max_lon=args.max_longitude,
-               min_lon=args.min_longitude, dd_lobes=args.dd_lobes)
+    cmac_radar = cmac(radar, sonde, args.facility, town, alt)
+    sonde.close()
+
+    radar_start_date = netCDF4.num2date(radar.time['data'][0],
+                                        radar.time['units'])
+    year_str = "%04d" % radar_start_date.year
+    month_str = "%02d" % radar_start_date.month
+    day_str = "%02d" % radar_start_date.day
+    hour_str = "%02d" % radar_start_date.hour
+    minute_str = "%02d" % radar_start_date.minute
+    second_str = "%02d" % radar_start_date.second
+
+    del radar
+
+    if args.out_radar_directory is None:
+        pyart.io.write_cfradial(
+            (os.path.expanduser('~') + '/sgpxsaprcmacsur' + args.facility
+             + '.c1.' + year_str + month_str + day_str + '.' + hour_str
+             + minute_str + second_str + '.nc'), cmac_radar)
+        print('## A CMAC radar object has been created at '
+              + os.path.expanduser('~') + '/sgpxsaprcmacsur' + args.facility
+              + '.c1.' + year_str + month_str + day_str + '.' + hour_str
+              + minute_str + second_str + '.nc')
+    else:
+        pyart.io.write_cfradial(
+            (args.out_radar_directory + '/sgpxsaprcmacsur' + args.facility
+             + '.c1.' + year_str + month_str + day_str + '.' + hour_str
+             + minute_str + second_str + '.nc'), cmac_radar)
+        print('## A CMAC radar object has been created at '
+              + args.out_radar_directory + '/sgpxsaprcmacsur' + args.facility
+              + '.c1.' + year_str + month_str + day_str + '.' + hour_str
+              + minute_str + second_str + '.nc')
+
+    quicklooks(cmac_radar, args.facility,
+               image_directory=args.image_directory,
+               sweep=args.sweep, max_lat=max_lat,
+               min_lat=min_lat, max_lon=max_lon,
+               min_lon=min_lon, dd_lobes=args.dd_lobes,
+               dd_lobes_radar1_lon=radar1_dms_lon,
+               dd_lobes_radar1_lat=radar1_dms_lat,
+               dd_lobes_radar2_lon=radar2_dms_lon,
+               dd_lobes_radar2_lat=radar2_dms_lat)
+
     del cmac_radar
     print('##')
     if args.image_directory is None:

--- a/scripts/xsapr_cmac_dask
+++ b/scripts/xsapr_cmac_dask
@@ -120,6 +120,9 @@ def main():
         'clutter_file', type=str,
         help='Path to clutter file')
     parser.add_argument(
+        'site', type=str, help=('Site ID, for example I4, for which X-SAPR',
+                                'data CMAC2.0 will run on.')) 
+    parser.add_argument(
         '-o', '--out_radar', type=str, default=None,
         help=('Out file path and name to use for the CMAC radar.',
               'If not provided, radar is written to users home',
@@ -130,23 +133,8 @@ def main():
               'If not provided, images are written to users home',
               'directory.'))
     parser.add_argument(
-        '-alt', '--altitude', type=float, default=320.0,
-        help='Value to use as default altitude for the radar object')
-    parser.add_argument(
         '-sw', '--sweep', type=int, default=3,
         help='Value for the sweep to plot.')
-    parser.add_argument(
-        '-maxlat', '--max_latitude', type=float, default=37.0,
-        help='Value to use as max latitude for the bounds of the plots.')
-    parser.add_argument(
-        '-minlat', '--min_latitude', type=float, default=36.0,
-        help='Value to use as min latitude for the bounds of the plots.')
-    parser.add_argument(
-        '-maxlon', '--max_longitude', type=float, default=-97.0,
-        help='Value to use as max longitude for the bounds of the plots.')
-    parser.add_argument(
-        '-minlon', '--min_longitude', type=float, default=-98.3,
-        help='Value to use as min longitude for the bounds of the plots.')
     parser.add_argument(
         '-sched', '--scheduler_file', type=str, default='~/scheduler.json',
         help='Path to dask scheduler json file')
@@ -169,8 +157,33 @@ def main():
 
     args = parser.parse_args()
 
+    if args.site == 'I4':
+        from cmac import CONFIG_XSAPR_I4 as radar_config
+    elif args.site == 'I5':
+        from cmac import CONFIG_XSAPR_I5 as radar_config
+    elif args.site == 'I6':
+        from cmac import CONFIG_XSAPR_I6 as radar_config
+    
+
+    site_id = radar_config['site']
+    town = radar_config['town']
+    x_compass = radar_config['x_compass']
+    site_alt = radar_config['site_alt']
+    field_shape = radar_config['field_shape']
+    max_lat = radar_config['max_lat']
+    min_lat = radar_config['min_lat']
+    max_lon = radar_config['max_lon']
+    min_lon = radar_config['min_lon']
+    site_i6_dms_lat = radar_config['site_i6_dms_lat'] 
+    site_i6_dms_lon = radar_config['site_i6_dms_lon']
+    site_i5_dms_lat = radar_config['site_i5_dms_lat']
+    site_i5_dms_lon = radar_config['site_i5_dms_lon']
+    site_i4_dms_lat = radar_config['site_i4_dms_lat']
+    site_i4_dms_lon = radar_config['site_i4_dms_lon']
+
     if os.path.isdir(args.radar_path):
-        radar_files = glob.glob(args.radar_path + '/**/*XSW*', recursive=True)
+        radar_files = glob.glob(args.radar_path + '/**/*' + x_compass
+                                + '*', recursive=True)
     elif os.path.isfile(args.radar_path):
         with open(args.radar_path) as f:
             radar_files = f.readlines()
@@ -183,9 +196,9 @@ def main():
     # Get dates of radar files from the file name.
     radar_times = []
     for file_name in radar_files:
-        where_xsw = file_name.find('XSW')
+        where_x = file_name.find(x_compass)
         radar_times.append(
-            datetime.datetime.strptime(file_name[where_xsw+3:where_xsw+15],
+            datetime.datetime.strptime(file_name[where_x+3:where_x+15],
                                        '%y%m%d%H%M%S'))
 
     # Connect to dask client.

--- a/scripts/xsapr_cmac_dask
+++ b/scripts/xsapr_cmac_dask
@@ -46,20 +46,20 @@ def run_cmac_and_plotting(radar_file_path, radar_config,
     max_lon = radar_config['max_lon']
     min_lon = radar_config['min_lon']
     if facility_id == 'I4':
-        radar1_dms_lon = radar_config['site_i4_dms_lon']
-        radar1_dms_lat = radar_config['site_i4_dms_lat']
-        radar2_dms_lon = radar_config['site_i5_dms_lon']
-        radar2_dms_lat = radar_config['site_i5_dms_lat']
+        dms_radar1_coords = [radar_config['site_i4_dms_lon'],
+                             radar_config['site_i4_dms_lat']]
+        dms_radar2_coords = [radar_config['site_i5_dms_lon'],
+                             radar_config['site_i5_dms_lat']]
     if facility_id == 'I5':
-        radar1_dms_lon = radar_config['site_i5_dms_lon']
-        radar1_dms_lat = radar_config['site_i5_dms_lat']
-        radar2_dms_lon = radar_config['site_i4_dms_lon']
-        radar2_dms_lat = radar_config['site_i4_dms_lat']
+        dms_radar1_coords = [radar_config['site_i5_dms_lon'],
+                             radar_config['site_i5_dms_lat']]
+        dms_radar2_coords = [radar_config['site_i4_dms_lon'],
+                             radar_config['site_i4_dms_lat']]
     if facility_id == 'I6':
-        radar1_dms_lon = radar_config['site_i6_dms_lon']
-        radar1_dms_lat = radar_config['site_i6_dms_lat']
-        radar2_dms_lon = radar_config['site_i4_dms_lon']
-        radar2_dms_lat = radar_config['site_i4_dms_lat']
+        dms_radar1_coords = [radar_config['site_i6_dms_lon'],
+                             radar_config['site_i6_dms_lat']]
+        dms_radar2_coords = [radar_config['site_i4_dms_lon'],
+                             radar_config['site_i4_dms_lat']]
 
     radar_start_date = netCDF4.num2date(radar.time['data'][0],
                                         radar.time['units'])
@@ -133,10 +133,8 @@ def run_cmac_and_plotting(radar_file_path, radar_config,
                sweep=args.sweep, max_lat=max_lat,
                min_lat=min_lat, max_lon=max_lon,
                min_lon=min_lon, dd_lobes=args.dd_lobes,
-               dd_lobes_radar1_lon=radar1_dms_lon,
-               dd_lobes_radar1_lat=radar1_dms_lat,
-               dd_lobes_radar2_lon=radar2_dms_lon,
-               dd_lobes_radar2_lat=radar2_dms_lat)
+               dms_radar1_coords=dms_radar1_coords,
+               dms_radar2_coords=dms_radar2_coords)
 
     # Delete the cmac_radar object and move on to the next radar file.
     del cmac_radar

--- a/scripts/xsapr_cmac_dask
+++ b/scripts/xsapr_cmac_dask
@@ -17,10 +17,10 @@ import netCDF4
 import pyart
 
 from cmac import cmac, quicklooks, get_sounding_times, get_sounding_file_name
-from cmac import xsapr_clutter
 
 
-def run_cmac_and_plotting(radar_file_path, sounding_times, args):
+def run_cmac_and_plotting(radar_file_path, radar_config,
+                          sounding_times, args):
     """ For dask we need the radar plotting routines all in one subroutine. """
     try:
         radar = pyart.io.read(radar_file_path)
@@ -35,6 +35,31 @@ def run_cmac_and_plotting(radar_file_path, sounding_times, args):
             subprocess.call('chmod -R g+rw ' + path, shell=True)
         shutil.move(radar_file_path, path)
         return
+
+    # Defining variables based on the argument args.facility.
+    facility_id = radar_config['facility']
+    town = radar_config['town']
+    alt = radar_config['site_alt']
+    field_shape = radar_config['field_shape']
+    max_lat = radar_config['max_lat']
+    min_lat = radar_config['min_lat']
+    max_lon = radar_config['max_lon']
+    min_lon = radar_config['min_lon']
+    if facility_id == 'I4':
+        radar1_dms_lon = radar_config['site_i4_dms_lon']
+        radar1_dms_lat = radar_config['site_i4_dms_lat']
+        radar2_dms_lon = radar_config['site_i5_dms_lon']
+        radar2_dms_lat = radar_config['site_i5_dms_lat']
+    if facility_id == 'I5':
+        radar1_dms_lon = radar_config['site_i5_dms_lon']
+        radar1_dms_lat = radar_config['site_i5_dms_lat']
+        radar2_dms_lon = radar_config['site_i4_dms_lon']
+        radar2_dms_lat = radar_config['site_i4_dms_lat']
+    if facility_id == 'I6':
+        radar1_dms_lon = radar_config['site_i6_dms_lon']
+        radar1_dms_lat = radar_config['site_i6_dms_lat']
+        radar2_dms_lon = radar_config['site_i4_dms_lon']
+        radar2_dms_lat = radar_config['site_i4_dms_lat']
 
     radar_start_date = netCDF4.num2date(radar.time['data'][0],
                                         radar.time['units'])
@@ -52,13 +77,15 @@ def run_cmac_and_plotting(radar_file_path, sounding_times, args):
     else:
         the_path = (args.out_radar + '/' + year_str +  month_str
                     + day_str)
-    file_name = (the_path + '/sgpxsaprcmacsurI5.c1.' + year_str + month_str
-                 + day_str + '.' + hour_str + minute_str + second_str + '.nc')
+    file_name = (the_path + '/sgpxsaprcmacsur' + facility_id + '.c1.'
+                 + year_str + month_str + day_str + '.' + hour_str
+                 + minute_str + second_str + '.nc')
 
-    if args.overwrite is False:
-        if os.path.exists(file_name) is True:
-            print(file_name + ' already exists.')
-            return
+    # If overwrite is False, checks to see if the cmac_radar file
+    # already exists. If so, CMAC 2.0 is not used on the original radar file.
+    if args.overwrite is False and os.path.exists(file_name) is True:
+        print(file_name + ' already exists.')
+        return
 
     if not os.path.exists(the_path):
         os.makedirs(the_path)
@@ -74,29 +101,44 @@ def run_cmac_and_plotting(radar_file_path, sounding_times, args):
     radar.add_field(
         'xsapr_clutter', clutter_field_dict, replace_existing=True)
     del clutter
+
+    # Retrieve closest sonde in time to the time of the radar file.
     closest_time = min(sounding_times,
                        key=lambda d: abs(d - radar_start_date))
     sonde_file = get_sounding_file_name(args.sonde_path,
                                         closest_time)
     sonde = netCDF4.Dataset(sonde_file)
-    cmac_radar = cmac(radar, sonde, alt=args.altitude)
 
-    ## Free up some memory
+    # Running the cmac code to produce a cmac_radar object.
+    cmac_radar = cmac(radar, sonde, facility_id, town, alt)
+
+    # Free up some memory.
     del radar
     sonde.close()
 
+    # Produce the cmac_radar file from the cmac_radar object.
     pyart.io.write_cfradial(file_name, cmac_radar)
     print('## A CMAC radar object has been created at ' + file_name)
+
+    # Providing the image_directory and checking if it already exists.
     img_directory = (args.image_directory + '/' + year_str + month_str
                      + day_str + '.' + hour_str + minute_str + second_str)
     if not os.path.exists(img_directory):
         os.makedirs(img_directory)
         subprocess.call('chmod -R g+rw ' + img_directory, shell=True)
 
-    quicklooks(cmac_radar, image_directory=img_directory,
-               sweep=args.sweep, max_lat=args.max_latitude,
-               min_lat=args.min_latitude, max_lon=args.max_longitude,
-               min_lon=args.min_longitude, dd_lobes=args.dd_lobes)
+    # Producing all the cmac_radar quicklooks.
+    quicklooks(cmac_radar, facility_id,
+               image_directory=img_directory,
+               sweep=args.sweep, max_lat=max_lat,
+               min_lat=min_lat, max_lon=max_lon,
+               min_lon=min_lon, dd_lobes=args.dd_lobes,
+               dd_lobes_radar1_lon=radar1_dms_lon,
+               dd_lobes_radar1_lat=radar1_dms_lat,
+               dd_lobes_radar2_lon=radar2_dms_lon,
+               dd_lobes_radar2_lat=radar2_dms_lat)
+
+    # Delete the cmac_radar object and move on to the next radar file.
     del cmac_radar
     return
 
@@ -120,8 +162,8 @@ def main():
         'clutter_file', type=str,
         help='Path to clutter file')
     parser.add_argument(
-        'site', type=str, help=('Site ID, for example I4, for which X-SAPR',
-                                'data CMAC2.0 will run on.')) 
+        'facility', type=str, help=('Facility ID, for example I4, for which',
+                                    'X-SAPR data CMAC2.0 will run on.'))
     parser.add_argument(
         '-o', '--out_radar', type=str, default=None,
         help=('Out file path and name to use for the CMAC radar.',
@@ -145,8 +187,8 @@ def main():
     parser.add_argument('--dd-lobes', dest='dd_lobes', action='store_true',
                         help='Plot Dual Doppler lobes between i4 and i5.')
     parser.add_argument('--no-dd-lobes', dest='dd_lobes', action='store_false',
-                        help=('Do not plot Dual Doppler lobes' + 
-                             ' between i4 and i5.'))
+                        help=('Do not plot Dual Doppler lobes'
+                              + ' between i4 and i5.'))
     parser.add_argument('--overwrite', dest='overwrite', action='store_true',
                         help='Option to overwrite prexisting cmac files.')
     parser.add_argument('--no-overwrite', dest='overwrite',
@@ -157,30 +199,15 @@ def main():
 
     args = parser.parse_args()
 
-    if args.site == 'I4':
-        from cmac import CONFIG_XSAPR_I4 as radar_config
-    elif args.site == 'I5':
-        from cmac import CONFIG_XSAPR_I5 as radar_config
-    elif args.site == 'I6':
-        from cmac import CONFIG_XSAPR_I6 as radar_config
-    
+    # Importing radar config data depending on facilty_id
+    if args.facility == 'I4':
+        from cmac import config_xsapr_i4 as radar_config
+    elif args.facility == 'I5':
+        from cmac import config_xsapr_i5 as radar_config
+    elif args.facility == 'I6':
+        from cmac import config_xsapr_i6 as radar_config
 
-    site_id = radar_config['site']
-    town = radar_config['town']
     x_compass = radar_config['x_compass']
-    site_alt = radar_config['site_alt']
-    field_shape = radar_config['field_shape']
-    max_lat = radar_config['max_lat']
-    min_lat = radar_config['min_lat']
-    max_lon = radar_config['max_lon']
-    min_lon = radar_config['min_lon']
-    site_i6_dms_lat = radar_config['site_i6_dms_lat'] 
-    site_i6_dms_lon = radar_config['site_i6_dms_lon']
-    site_i5_dms_lat = radar_config['site_i5_dms_lat']
-    site_i5_dms_lon = radar_config['site_i5_dms_lon']
-    site_i4_dms_lat = radar_config['site_i4_dms_lat']
-    site_i4_dms_lon = radar_config['site_i4_dms_lon']
-
     if os.path.isdir(args.radar_path):
         radar_files = glob.glob(args.radar_path + '/**/*' + x_compass
                                 + '*', recursive=True)
@@ -218,7 +245,7 @@ def main():
         else:
             future_list.append(
                 client.submit(run_cmac_and_plotting, the_file,
-                              sounding_times, args))
+                              radar_config, sounding_times, args))
 
     ## Do radar object loading on compute nodes.
     if args.image_directory is None:


### PR DESCRIPTION
**Note: Works locally, have not test xsapr_cmac_dask yet, but the changes have been made to that file, I will accept this request once I test it on Stratus. Information on pull request below.

Many files have been changed to now utilize the new config.py file. Each radar has a different location, id, etc. So instead of different environments set for each radar, user just in the command line adds:
``` 'I5' ``` after the clutter_file_path argument in the command line. This then removes the need also for arguments such as max lat and lon, alt, etc.