### PR TITLE
FIX: Memory leaks in quicklook plots.

### DIFF
--- a/cmac/cmac_quicklooks.py
+++ b/cmac/cmac_quicklooks.py
@@ -143,7 +143,6 @@ def quicklooks(radar, config, image_directory=None,
                   'snow': 'cyan',
                   'melting': 'yellow'}
     lab_colors = ['red', 'cyan', 'grey', 'green', 'yellow']
-    print(radar.fields.keys())
     if 'ground_clutter' in radar.fields.keys():
         cat_colors['clutter'] = 'black'
         lab_colors = np.append(lab_colors, 'black')
@@ -215,7 +214,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/cmac_four_panel_plot' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
     # Creating a plot with reflectivity corrected with gate ids.
     cmac_gates = pyart.correct.GateFilter(radar)
@@ -246,7 +246,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/masked_corrected_reflectivity' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
 
     # Creating a plot with reflectivity corrected with attenuation.
@@ -270,7 +271,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/corrected_reflectivity' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
     # Creating a plot with differential phase.
     display = pyart.graph.RadarMapDisplay(radar)
@@ -285,7 +287,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/differential_phase' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
 
     # Creating a plot of specific attenuation.
@@ -305,7 +308,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/specific_attenuation' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
     # Creating a plot of corrected differential phase.
     display = pyart.graph.RadarMapDisplay(radar)
@@ -326,7 +330,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/corrected_differential_phase' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
     # Creating a plot of corrected specific differential phase.
     display = pyart.graph.RadarMapDisplay(radar)
@@ -347,7 +352,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/corrected_specific_diff_phase' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
     # Creating a plot with region dealias corrected velocity.
     display = pyart.graph.RadarMapDisplay(radar)
@@ -365,7 +371,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/corrected_velocity' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig) 
+    del fig, ax, display
 
     # Creating a plot of rain rate A
     display = pyart.graph.RadarMapDisplay(radar)
@@ -382,7 +389,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/rain_rate_A' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
     # Creating a plot of filtered corrected differential phase.
     display = pyart.graph.RadarMapDisplay(radar)
@@ -404,7 +412,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/filtered_corrected_differential_phase' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
     # Creating a plot of filtered corrected specific differential phase.
     display = pyart.graph.RadarMapDisplay(radar)
@@ -426,7 +435,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/filtered_corrected_specific_diff_phase' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
     # Creating a plot of corrected differential phase.
     display = pyart.graph.RadarMapDisplay(radar)
@@ -447,7 +457,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/specific_differential_attenuation' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
     # Creating a plot of corrected differential phase.
     display = pyart.graph.RadarMapDisplay(radar)
@@ -469,7 +480,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/path_integrated_differential_attenuation' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
     # Creating a plot of corrected differential phase.
     display = pyart.graph.RadarMapDisplay(radar)
@@ -490,7 +502,8 @@ def quicklooks(radar, config, image_directory=None,
     fig.savefig(
         image_directory
         + '/corrected_differential_reflectivity' + combined_name + '.png')
-    del fig, ax
+    plt.close(fig)
+    del fig, ax, display
 
 
 def _generate_title(radar, field, sweep):


### PR DESCRIPTION
Fixed a few memory leaks in the quicklook plot routine. The figures being generated were not being cleared from memory. Matplotlib won't clear the figure from memory unless you do a plt.close on it.