### PR TITLE
ADD: Support for pangeo's binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -19,6 +19,7 @@ dependencies:
 # radar
   - coincbc=2.9.9
   - act-atmos
+  - scikit-fuzzy
   - pip:
     - git+https://github.com/CSU-Radarmet/CSU_RadarTools.git
     - git+https://github.com/EVS-ATMOS/cmac2.0

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - pip
 # radar
   - coincbc=2.9.9
-  - act_atmos
+  - act-atmos
   - pip:
     - git+https://github.com/CSU-Radarmet/CSU_RadarTools.git
     - git+https://github.com/EVS-ATMOS/cmac2.0

--- a/notebooks/CAMC2.0_CSAPR2_demo.ipynb
+++ b/notebooks/CAMC2.0_CSAPR2_demo.ipynb
@@ -6,30 +6,14 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "## You are using the Python ARM Radar Toolkit (Py-ART), an open source\n",
-      "## library for working with weather radar data. Py-ART is partly\n",
-      "## supported by the U.S. Department of Energy as part of the Atmospheric\n",
-      "## Radiation Measurement (ARM) Climate Research Facility, an Office of\n",
-      "## Science user facility.\n",
-      "##\n",
-      "## If you use this software to prepare a publication, please cite:\n",
-      "##\n",
-      "##     JJ Helmus and SM Collis, JORS 2016, doi: 10.5334/jors.119\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/scollis/anaconda3/envs/cmac2/lib/python3.6/site-packages/pyart/graph/cm.py:104: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison\n",
-      "  if 'red' in spec:\n",
-      "/Users/scollis/anaconda3/envs/cmac2/lib/python3.6/site-packages/pyart/graph/cm_colorblind.py:32: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison\n",
-      "  if 'red' in spec:\n"
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'pyart'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-1-d20e7d291629>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[1;31m#Py-ART, simply the best sowftware around.. Give those guys a grant\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      6\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mcartopy\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 7\u001b[1;33m \u001b[1;32mimport\u001b[0m \u001b[0mpyart\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      8\u001b[0m \u001b[1;31m#timezone info\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      9\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mpytz\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mModuleNotFoundError\u001b[0m: No module named 'pyart'"
      ]
     }
    ],
@@ -66,7 +50,19 @@
     "import matplotlib.colors as mc\n",
     "import matplotlib.ticker as mt\n",
     "import matplotlib.font_manager as fm\n",
+    "import act\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download sonde and radar data\n",
+    "act.discovery.download_data('rjackson', '', 'corcsapr2cfrppiM1.a1', '2018-11-05', '2018-11-06')\n",
+    "act.discovery.download_data('rjackson', '', 'corsondewnpnM1.b1', '2018-11-05', '2018-11-06')"
    ]
   },
   {
@@ -2372,7 +2368,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Using both ACT to download the data and binder to host the repository, it is now possible to launch a binder instance of CMAC2.0.