### PR TITLE
FIX: NCP filtering in clutter code

### DIFF
--- a/cmac/default_config.py
+++ b/cmac/default_config.py
@@ -687,7 +687,7 @@ _DEFAULT_CMAC_VALUES = {
         'phidp_flipped': ['uncorrected_differential_phase','differential_phase'],
         'mbfs': nsa_xsapr_ppi_mbfs,
         'hard_const': nsa_xsapr_ppi_hard_const,
-        'gen_clutter_from_refl': True,
+        'gen_clutter_from_refl': False,
         'ref_offset': 0.0,
         'gen_clutter_from_refl_diff': -0.2,
         'gen_clutter_from_refl_alt': 2000.0,

--- a/cmac/radar_clutter.py
+++ b/cmac/radar_clutter.py
@@ -82,7 +82,7 @@ def tall_clutter(files, config,
             height = radar.gate_z["data"]
             up_in_the_air = height > max_height
             the_mask = np.logical_or.reduce(
-                (ncp < 0.8, reflect_array.mask, up_in_the_air))
+                (ncp < 0.9, reflect_array.mask, up_in_the_air))
             reflect_array = np.ma.masked_where(the_mask, reflect_array)
             del radar
             if reflect_array.shape == first_shape:
@@ -101,9 +101,9 @@ def tall_clutter(files, config,
                 ncp = deepcopy(radar.fields[ncp_field]['data'])
                 height = radar.gate_z["data"]
                 reflect_array = np.ma.masked_where(
-                        np.logical_and(height > max_height, ncp < 0.8),
+                        np.logical_or(height > max_height, ncp < 0.8),
                         reflect_array)
-               
+                    
                 if first_shape == 0:
                     first_shape = reflect_array.shape
                     clutter_radar = radar

--- a/scripts/cmac
+++ b/scripts/cmac
@@ -8,6 +8,7 @@ import importlib
 
 import netCDF4
 import pyart
+import numpy as np
 
 from cmac import cmac, get_cmac_values, quicklooks, area_coverage
 
@@ -66,7 +67,24 @@ def main():
     if args.clutter_file is not None:
         # Load clutter files.
         clutter_radar = pyart.io.read(args.clutter_file)
-        clutter_field_dict = clutter_radar.fields['ground_clutter']
+        clutter_field_dict = clutter_radar.fields['ground_clutter'].copy()
+        # For XSAPR data at NSA, sometimes only 3 of 6 sweeps present
+        # Just copy clutter information from bottom sweeps
+        if clutter_radar.nsweeps > radar.nsweeps:
+            fname = [x for x in radar.fields.keys()][0]
+            clutter_field_dict["data"] = np.zeros_like(
+                    radar.fields[fname]["data"])
+            i = 0
+            for azi_angle in radar.fixed_angle["data"]:
+                ind = np.argwhere(clutter_radar.fixed_angle["data"] == azi_angle)
+                if len(ind) > 0:
+                    clutter = clutter_radar.get_field(
+                            int(ind), 'ground_clutter')
+                    
+                    start, end = radar.get_start_end(i)
+                    clutter_field_dict["data"][
+                            int(start):int(end+1)] = clutter
+                i = i + 1
         radar.add_field(
             'ground_clutter', clutter_field_dict, replace_existing=True)
         del clutter_radar
@@ -94,7 +112,7 @@ def main():
     cmac_config = get_cmac_values(args.config)
     save_name = cmac_config['save_name']
 
-    ref_10_per, ref_40_per = area_coverage(radar)
+    ref_10_per, ref_40_per = area_coverage(cmac_radar)
     cmac_radar.metadata['precipitation_coverage_percentage'] = ref_10_per
     cmac_radar.metadata['convection_coverage_percentage'] = ref_40_per
 


### PR DESCRIPTION
I fixed an issue with the clutter code not filtering out periods of low NCP, misclassifying clear air as clutter.