### PR TITLE
FIX: Syntax errors in cmac_radar.py

### DIFF
--- a/cmac/cmac_radar.py
+++ b/cmac/cmac_radar.py
@@ -49,7 +49,6 @@ def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
     -------
     radar : Radar
         Radar object with new CMAC added fields.
-
     """
     # Retrieve values from the configuration file.
     cmac_config = get_cmac_values(config)


### PR DESCRIPTION
There was a syntax error in the main branch of cmac2.0 that was fixed in the sail_fixes branch. However, it did not make it to the main branch the first time around.