### PR TITLE
SAIL Cumulative Beam Block Flag

### DIFF
--- a/cmac/cmac_radar.py
+++ b/cmac/cmac_radar.py
@@ -16,6 +16,7 @@ from .cmac_processing import (
     snow_rate)
 from .config import get_cmac_values, get_field_names, get_metadata, get_zs_relationships
 
+
 def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
          meta_append=None, verbose=True, snow_density=1, snowfall=True):
     """
@@ -62,10 +63,10 @@ def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
 
     # Obtaining variables needed for fuzzy logic.
 
-    radar_start_date = netCDF4.num2date(
-        radar.time['data'][0], radar.time['units'],
-        only_use_cftime_datetimes=False, only_use_python_datetimes=True)
-    print('##', str(radar_start_date))
+    ##radar_start_date = netCDF4.num2date(
+    ##    radar.time['data'][0], radar.time['units'],
+    ##    only_use_cftime_datetimes=False, only_use_python_datetimes=True)
+    ##print('##', str(radar_start_date))
 
     temp_field = field_config['temperature']
     alt_field = field_config['altitude']
@@ -220,6 +221,11 @@ def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
 
     if 'cbb_flag' in radar.fields.keys():
         cbb = radar.fields['cbb_flag']['data']
+        if cbb.shape[0] < radar.fields['gate_id']['data'].shape[0]:
+            # find the difference in shape
+            sdiff = radar.fields['gate_id']['data'].shape[0] - cbb.shape[0]
+            # pad the cbb gate to match the radar
+            cbb = np.pad(cbb, ((0, sdiff), (0, 0)),  'maximum')
         radar.fields['gate_id']['data'][cbb == 1] = 6
         notes = radar.fields['gate_id']['notes']
         radar.fields['gate_id']['notes'] = notes + ',6:terrain_blockage'

--- a/cmac/default_config.py
+++ b/cmac/default_config.py
@@ -299,7 +299,7 @@ _DEFAULT_METADATA = {
         'translator': 'Scott Collis, ANL.',
         'mentors': "https://www.arm.gov/connect-with-arm/organization/instrument-mentors/list#xprecipradar",
         'references': 'See XPRECIPRADAR Instrument Handbook',
-        'source': "Colorado State University X-Band Preciptiation Radar (XPRECIPRADAR) (DOI: 10.5439/1844501) "
+        'source': "Colorado State University X-Band Preciptiation Radar (XPRECIPRADAR) (DOI: 10.5439/1844501) ",
         'institution': 'U.S. Department of Energy Atmospheric Radiation '
                        + 'Measurement (ARM) Climate Research Facility',
         'platform_id': 'xprecipradarcmacppi',

--- a/cmac/default_config.py
+++ b/cmac/default_config.py
@@ -295,11 +295,11 @@ _DEFAULT_METADATA = {
         'known_issues': 'False phidp jumps in insect regions. Still uses old '
                         + 'Giangrande code. Issues with some snow below '
                         + 'melting layer.',
-        'developers': "Robert Jackson, ANL. Zachary Sherman, ANL., Maxwell Grover, ANL. Joseph OBrien, ANL.",
+        'developers': "Robert Jackson, ANL., Zachary Sherman, ANL., Maxwell Grover, ANL., Joseph OBrien, ANL.",
         'translator': 'Scott Collis, ANL.',
         'mentors': "https://www.arm.gov/connect-with-arm/organization/instrument-mentors/list#xprecipradar",
         'references': 'See XPRECIPRADAR Instrument Handbook',
-        'source': "Colorado State University X-Band Preciptiation Radar (XPRECIPRADAR) (DOI: 10.5439/1844501) ",
+        'source': "Colorado State University X-Band Precipitation Radar (XPRECIPRADAR) (DOI: 10.5439/1844501) ",
         'institution': 'U.S. Department of Energy Atmospheric Radiation '
                        + 'Measurement (ARM) Climate Research Facility',
         'platform_id': 'xprecipradarcmacppi',


### PR DESCRIPTION
Corrections to cmac_radar.py that checks if the cumulative beam block flag array dimensions are different from radar range shape. Pads ccb flag to match the radar object. 

Small grammar corrections to default_config file and fix to syntax error