### PR TITLE
ADD: SAIL Correction for Reflectivity Offsets

### DIFF
--- a/cmac/cmac_radar.py
+++ b/cmac/cmac_radar.py
@@ -18,7 +18,7 @@ from .config import get_cmac_values, get_field_names, get_metadata, get_zs_relat
 
 
 def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
-         meta_append=None, verbose=True, snow_density=1, snowfall=True):
+         meta_append=None, verbose=True, snow_density=0.073, snowfall=True):
     """
     Corrected Moments in Antenna Coordinates
 
@@ -111,7 +111,7 @@ def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
     if flip_velocity:
         radar.fields[vel_field]['data'] = radar.fields[
             vel_field]['data'] * -1.0
-    print(sonde.variables[temp_field][:])
+
     z_dict, temp_dict = pyart.retrieve.map_profile_to_gates(
         sonde.variables[temp_field][:], sonde.variables[alt_field][:], radar)
 

--- a/cmac/cmac_radar.py
+++ b/cmac/cmac_radar.py
@@ -92,8 +92,12 @@ def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
         else:
             radar.fields[
                 field_config['input_zdr']]['data'] += cmac_config['zdr_offset']
-
-
+    
+    # Reflectivity offsets
+    if cmac_config["ref_offset"]:
+        # note need input reflectivity, not corrected reflectivity variable name
+        radar.fields[field_config["reflectivity"]]['data'] += cmac_config["ref_offset"]
+        
     # flipping phidp
     if 'flip_phidp' not in cmac_config.keys():
         cmac_config['flip_phidp'] = False


### PR DESCRIPTION
Since radar calibrations are typically applied within ARM b1-level processing, offsets to the radar reflectivity have yet to be applied within CMAC. For SAIL, b1-level files were not created and CMAC was processed from the a0-level raw data files produced from the Colorado State University radar team. Therefore, quick correction for radar reflectivity offsets has been applied to the CMAC processing. 

Additionally, the default snow density value for SAIL was reapplied after analysis and paths to radar files updated for the migration of drives on OLCF's Cumulus. 