### PR TITLE
FIX: Eliminating SNR field when it should be preserved.

### DIFF
--- a/cmac/cmac_radar.py
+++ b/cmac/cmac_radar.py
@@ -159,8 +159,8 @@ def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
         radar.add_field('signal_to_noise_ratio', snr, replace_existing=True)
     else:
         radar.fields[
-            'signal_to_noise_ratio'] = radar.fields.pop(
-                field_config['signal_to_noise_ratio'])
+            'signal_to_noise_ratio'] = radar.fields[
+                field_config['signal_to_noise_ratio']].copy()
     radar.add_field('velocity_texture', texture, replace_existing=True)
     if verbose:
         print('##    sounding_temperature')


### PR DESCRIPTION
A small fix to copy the SNR field instead of pop so that we preserve all of the input from the input datastream.