### PR TITLE
ADD: Use yaml files for configuration

### DIFF
--- a/cmac/cmac_ppi_quicklooks.py
+++ b/cmac/cmac_ppi_quicklooks.py
@@ -21,7 +21,7 @@ plt.switch_backend('agg')
 
 
 def quicklooks_ppi(radar, config, sweep=None, image_directory=None,
-                   dd_lobes=True):
+                   dd_lobes=True, config_file=None):
     """
     Quicklooks PPI, images produced with regards to CMAC
 
@@ -40,6 +40,9 @@ def quicklooks_ppi(radar, config, sweep=None, image_directory=None,
         image file path is given, image path defaults to users home directory.
     dd_lobes : bool
         Plot DD lobes between radars if dd_lobes is True.
+    config_file : str or None
+        Path to a YAML file whose values override the built-in defaults for
+        the named ``config`` radar.
 
     """
     if image_directory is None:
@@ -50,8 +53,8 @@ def quicklooks_ppi(radar, config, sweep=None, image_directory=None,
         only_use_cftime_datetimes=False, only_use_python_datetimes=True)
 
     # Retrieve the plot parameter values based on the radar.
-    plot_config = get_plot_values(config)
-    field_config = get_field_names(config)
+    plot_config = get_plot_values(config, config_file=config_file)
+    field_config = get_field_names(config, config_file=config_file)
     save_name = plot_config['save_name']
     date_string = datetime.strftime(radar_start_date, '%Y%m%d.%H%M%S')
     combined_name = '.' + save_name + '.' + date_string

--- a/cmac/cmac_radar.py
+++ b/cmac/cmac_radar.py
@@ -18,7 +18,8 @@ from .config import get_cmac_values, get_field_names, get_metadata, get_zs_relat
 from csu_radartools import csu_kdp
 
 def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
-         meta_append=None, verbose=True, snow_density=0.073, snowfall=True):
+         meta_append=None, verbose=True, snow_density=0.073, snowfall=True,
+         config_file=None):
     """
     Corrected Moments in Antenna Coordinates
 
@@ -45,6 +46,10 @@ def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
         If True, this will display more statistics.
     snow_density : float
         1 / Snow water equivalent ratio for snowfall rate
+    config_file : str or None
+        Path to a YAML file whose values override the built-in defaults for
+        the named ``config`` radar. See ``cmac.config`` for the expected
+        layout. When None, only the built-in defaults are used.
 
     Returns
     -------
@@ -52,10 +57,10 @@ def cmac(radar, sonde, config, geotiff=None, flip_velocity=False,
         Radar object with new CMAC added fields.
     """
     # Retrieve values from the configuration file.
-    cmac_config = get_cmac_values(config)
-    field_config = get_field_names(config)
-    meta_config = get_metadata(config)
-    zs_relationship_dict = get_zs_relationships()
+    cmac_config = get_cmac_values(config, config_file=config_file)
+    field_config = get_field_names(config, config_file=config_file)
+    meta_config = get_metadata(config, config_file=config_file)
+    zs_relationship_dict = get_zs_relationships(config_file=config_file)
     # Over write site altitude
 
     if 'site_alt' in cmac_config.keys():

--- a/cmac/cmac_rhi_quicklooks.py
+++ b/cmac/cmac_rhi_quicklooks.py
@@ -19,7 +19,8 @@ from .config import get_plot_values, get_field_names
 plt.switch_backend('agg')
 
 
-def quicklooks_rhi(radar, config, sweep=None, image_directory=None):
+def quicklooks_rhi(radar, config, sweep=None, image_directory=None,
+                   config_file=None):
     """
     Quicklooks RHI, images produced with regards to CMAC
 
@@ -36,6 +37,9 @@ def quicklooks_rhi(radar, config, sweep=None, image_directory=None):
     image_directory : str
         File path to the image folder of which to save the CMAC images. If no
         image file path is given, image path defaults to users home directory.
+    config_file : str or None
+        Path to a YAML file whose values override the built-in defaults for
+        the named ``config`` radar.
 
     """
     if image_directory is None:
@@ -46,8 +50,8 @@ def quicklooks_rhi(radar, config, sweep=None, image_directory=None):
         only_use_cftime_datetimes=False, only_use_python_datetimes=True)
 
     # Retrieve the plot parameter values based on the radar.
-    plot_config = get_plot_values(config)
-    field_config = get_field_names(config)
+    plot_config = get_plot_values(config, config_file=config_file)
+    field_config = get_field_names(config, config_file=config_file)
     save_name = plot_config['save_name']
     date_string = datetime.strftime(radar_start_date, '%Y%m%d.%H%M%S')
     combined_name = '.' + save_name + '.' + date_string

--- a/cmac/config.py
+++ b/cmac/config.py
@@ -7,48 +7,173 @@ CMAC 2.0 Configuration.
     get_field_names
     get_cmac_values
     get_plot_values
+    get_zs_relationships
+
+All getters accept an optional ``config_file`` argument. When supplied, the
+YAML file at that path is loaded and any values it contains override the
+defaults; anything not specified in the YAML falls back to the built-in
+defaults defined in ``cmac.default_config``.
+
+The YAML file mirrors the structure of the default dictionaries, e.g.::
+
+    metadata:
+      my_radar:
+        site_id: sgp
+        ...
+    field_names:
+      my_radar:
+        reflectivity: reflectivity
+        ...
+    cmac_values:
+      my_radar:
+        save_name: my_radar.c1
+        site_alt: 300
+        ...
+    plot_values:
+      my_radar:
+        sweep: 3
+        ...
+    zs_relationships:
+      My Relationship:
+        A: 100
+        B: 2
+        abbreviation: my_rel
 
 """
+
+import os
+from copy import deepcopy
 
 from .default_config import (_DEFAULT_METADATA, _DEFAULT_FIELD_NAMES,
                              _DEFAULT_CMAC_VALUES, _DEFAULT_PLOT_VALUES,
                              _DEFAULT_ZS_RELATIONSHIPS)
 
 
-def get_metadata(radar):
+# Cache of parsed YAML files keyed by (absolute_path, mtime) so repeated calls
+# during a single processing run don't re-read or re-parse the file.
+_YAML_CACHE = {}
+
+
+def _load_yaml_config(config_file):
+    """Return the parsed YAML config as a dict, using a small mtime cache."""
+    try:
+        import yaml
+    except ImportError as err:
+        raise ImportError(
+            "Loading a CMAC config from YAML requires PyYAML. "
+            "Install it with `pip install pyyaml` or `conda install pyyaml`."
+        ) from err
+
+    abs_path = os.path.abspath(config_file)
+    if not os.path.isfile(abs_path):
+        raise FileNotFoundError(
+            "CMAC config file not found: %s" % config_file)
+
+    mtime = os.path.getmtime(abs_path)
+    cached = _YAML_CACHE.get(abs_path)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+
+    with open(abs_path, 'r') as fh:
+        parsed = yaml.safe_load(fh) or {}
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            "CMAC config file %s must contain a mapping at the top level."
+            % config_file)
+
+    _YAML_CACHE[abs_path] = (mtime, parsed)
+    return parsed
+
+
+def _resolve(section, radar, defaults, config_file):
+    """Merge YAML overrides for ``radar`` on top of ``defaults[radar]``.
+
+    Returns a fresh dict so callers can mutate it without affecting either
+    the defaults or the YAML cache.
+    """
+    base = deepcopy(defaults.get(radar, {}))
+    if config_file is None:
+        return base
+
+    yaml_cfg = _load_yaml_config(config_file)
+    section_cfg = yaml_cfg.get(section) or {}
+    radar_overrides = section_cfg.get(radar)
+    if radar_overrides is None:
+        return base
+
+    if not isinstance(radar_overrides, dict):
+        raise ValueError(
+            "YAML config section '%s' for radar '%s' must be a mapping."
+            % (section, radar))
+
+    base.update(deepcopy(radar_overrides))
+    return base
+
+
+def get_metadata(radar, config_file=None):
     """
     Return a dictionary of metadata for a given radar. An empty dictionary
-    will be returned in no metadata dictionary exists for parameter radar.
+    will be returned if no metadata exists for ``radar`` in either the YAML
+    config or the defaults.
     """
-    if radar in _DEFAULT_METADATA:
-        return _DEFAULT_METADATA[radar].copy()
-    else:
-        return {}
+    return _resolve('metadata', radar, _DEFAULT_METADATA, config_file)
 
 
-def get_field_names(radar):
+def get_field_names(radar, config_file=None):
     """
-    Return the field name from the configuration file for a given field.
+    Return the field name mapping for a given radar. When ``config_file``
+    is provided, values from the YAML file override the defaults.
     """
-    return _DEFAULT_FIELD_NAMES[radar]
+    if config_file is None:
+        return _DEFAULT_FIELD_NAMES[radar]
+    merged = _resolve('field_names', radar, _DEFAULT_FIELD_NAMES, config_file)
+    if not merged:
+        raise KeyError(radar)
+    return merged
 
 
-def get_cmac_values(radar):
+def get_cmac_values(radar, config_file=None):
     """
     Return the values specific to a radar for processing the radar data,
-    using CMAC 2.0.
+    using CMAC 2.0. When ``config_file`` is provided, values from the YAML
+    file override the defaults.
     """
-    return _DEFAULT_CMAC_VALUES[radar].copy()
+    if config_file is None:
+        return _DEFAULT_CMAC_VALUES[radar].copy()
+    merged = _resolve('cmac_values', radar, _DEFAULT_CMAC_VALUES, config_file)
+    if not merged:
+        raise KeyError(radar)
+    return merged
 
 
-def get_plot_values(radar):
+def get_plot_values(radar, config_file=None):
     """
     Return the values specific to a radar for plotting the radar fields.
+    When ``config_file`` is provided, values from the YAML file override
+    the defaults.
     """
-    return _DEFAULT_PLOT_VALUES[radar].copy()
+    if config_file is None:
+        return _DEFAULT_PLOT_VALUES[radar].copy()
+    merged = _resolve('plot_values', radar, _DEFAULT_PLOT_VALUES, config_file)
+    if not merged:
+        raise KeyError(radar)
+    return merged
 
-def get_zs_relationships():
+
+def get_zs_relationships(config_file=None):
     """
-    Return the default set of Z-S relationships to use.
+    Return the set of Z-S relationships to use. When ``config_file`` is
+    provided, any relationships defined under the ``zs_relationships``
+    section of the YAML file override (or add to) the defaults.
     """
-    return _DEFAULT_ZS_RELATIONSHIPS
+    base = deepcopy(_DEFAULT_ZS_RELATIONSHIPS)
+    if config_file is None:
+        return base
+
+    yaml_cfg = _load_yaml_config(config_file)
+    zs_overrides = yaml_cfg.get('zs_relationships') or {}
+    if not isinstance(zs_overrides, dict):
+        raise ValueError(
+            "YAML config section 'zs_relationships' must be a mapping.")
+    base.update(deepcopy(zs_overrides))
+    return base

--- a/cmac/radar_clutter.py
+++ b/cmac/radar_clutter.py
@@ -18,11 +18,11 @@ except ImportError:
     pass
 
 
-def tall_clutter(files, config, 
+def tall_clutter(files, config,
                  clutter_thresh_min=0.0002,
                  clutter_thresh_max=0.25, radius=1,
                  max_height=2000., write_radar=True,
-                 out_file=None, use_dask=False):
+                 out_file=None, use_dask=False, config_file=None):
     """
     Wind Farm Clutter Calculation
 
@@ -58,6 +58,9 @@ def tall_clutter(files, config,
     use_dask : bool
         Use dask instead of running stats for calculation. The will reduce
         run time.
+    config_file : str or None
+        Path to a YAML file whose values override the built-in defaults for
+        the named ``config`` radar.
 
     Returns
     -------
@@ -67,7 +70,7 @@ def tall_clutter(files, config,
         other radar specifications.
 
     """
-    field_names = get_field_names(config)
+    field_names = get_field_names(config, config_file=config_file)
     refl_field = field_names["reflectivity"]
     vel_field = field_names["velocity"]
     ncp_field = field_names["normalized_coherent_power"]

--- a/cmac/tests/test_config.py
+++ b/cmac/tests/test_config.py
@@ -1,14 +1,20 @@
 """ Unit Tests for CMAC 2.0's config.py module. """
 
-from cmac import (get_cmac_values, get_field_names,
-                  get_plot_values, get_metadata)
+import os
+import textwrap
+
+import pytest
+
+from cmac.config import (get_cmac_values, get_field_names,
+                         get_plot_values, get_metadata,
+                         get_zs_relationships)
 
 
 def test_get_cmac_values():
     cmac_config = get_cmac_values('xsapr_i5_ppi')
     assert type(cmac_config) == dict
 
-    assert cmac_config['save_name'] == 'sgpxsaprcmacsurI5.c1'
+    assert cmac_config['save_name'] == 'sgpxsaprcmacsecI5.c1'
     assert cmac_config['site_alt'] == 328
     assert cmac_config['ref_offset'] == 0.0
     assert cmac_config['self_const'] == 60000.00
@@ -29,7 +35,7 @@ def test_get_metadata():
     assert meta_config['site_id'] == 'sgp'
     assert meta_config['facility_id'] == 'I5: Garber, OK'
     assert meta_config['version'] == '2.0 lite'
-    
+
 
 def test_get_plot_values():
     plot_config = get_plot_values('xsapr_i5_ppi')
@@ -40,3 +46,96 @@ def test_get_plot_values():
     assert plot_config['min_lon'] == -98.3
     assert plot_config['site_i5_dms_lat'] == (36, 29, 29.4)
     assert plot_config['site_i5_dms_lon'] == (-97, 35, 37.68)
+
+
+# -- YAML overrides ---------------------------------------------------------
+
+YAML_BODY = textwrap.dedent("""
+    cmac_values:
+      xsapr_i5_ppi:
+        ref_offset: 1.25
+        zdr_offset: 2.5
+      my_new_radar:
+        save_name: my_radar.c1
+        site_alt: 500
+        ref_offset: 0.5
+    metadata:
+      xsapr_i5_ppi:
+        developers: "Override Author"
+    field_names:
+      xsapr_i5_ppi:
+        reflectivity: my_reflectivity
+    plot_values:
+      xsapr_i5_ppi:
+        sweep: 7
+    zs_relationships:
+      My Test Relationship:
+        A: 99
+        B: 1.5
+        abbreviation: mytest
+    """)
+
+
+@pytest.fixture
+def yaml_config(tmp_path):
+    path = tmp_path / "user_config.yaml"
+    path.write_text(YAML_BODY)
+    return str(path)
+
+
+def test_yaml_overrides_cmac_values(yaml_config):
+    cfg = get_cmac_values('xsapr_i5_ppi', config_file=yaml_config)
+    # Overridden values come from YAML.
+    assert cfg['ref_offset'] == 1.25
+    assert cfg['zdr_offset'] == 2.5
+    # Untouched values still come from the defaults.
+    assert cfg['save_name'] == 'sgpxsaprcmacsecI5.c1'
+    assert cfg['site_alt'] == 328
+
+
+def test_yaml_overrides_metadata(yaml_config):
+    meta = get_metadata('xsapr_i5_ppi', config_file=yaml_config)
+    assert meta['developers'] == 'Override Author'
+    # Fallback for un-overridden keys.
+    assert meta['site_id'] == 'sgp'
+
+
+def test_yaml_overrides_field_names(yaml_config):
+    fields = get_field_names('xsapr_i5_ppi', config_file=yaml_config)
+    assert fields['reflectivity'] == 'my_reflectivity'
+    assert fields['temperature'] == 'tdry'
+
+
+def test_yaml_overrides_plot_values(yaml_config):
+    plot = get_plot_values('xsapr_i5_ppi', config_file=yaml_config)
+    assert plot['sweep'] == 7
+    assert plot['min_lon'] == -98.3
+
+
+def test_yaml_adds_new_radar(yaml_config):
+    cfg = get_cmac_values('my_new_radar', config_file=yaml_config)
+    assert cfg['save_name'] == 'my_radar.c1'
+    assert cfg['site_alt'] == 500
+    assert cfg['ref_offset'] == 0.5
+
+
+def test_yaml_adds_zs_relationship(yaml_config):
+    rels = get_zs_relationships(config_file=yaml_config)
+    assert 'My Test Relationship' in rels
+    assert rels['My Test Relationship']['A'] == 99
+    # Defaults still present.
+    assert 'Wolf and Snider (2012)' in rels
+
+
+def test_yaml_does_not_mutate_defaults(yaml_config):
+    # Mutate the dict returned via YAML and confirm defaults stay clean.
+    cfg = get_cmac_values('xsapr_i5_ppi', config_file=yaml_config)
+    cfg['ref_offset'] = 999
+    default_cfg = get_cmac_values('xsapr_i5_ppi')
+    assert default_cfg['ref_offset'] == 0.0
+
+
+def test_yaml_missing_file_raises(tmp_path):
+    missing = str(tmp_path / "nope.yaml")
+    with pytest.raises(FileNotFoundError):
+        get_cmac_values('xsapr_i5_ppi', config_file=missing)

--- a/documents/example_config.yaml
+++ b/documents/example_config.yaml
@@ -1,0 +1,73 @@
+# Example CMAC 2.0 user configuration.
+#
+# Pass this file via the `config_file=` argument on any of:
+#   cmac.get_metadata, cmac.get_field_names, cmac.get_cmac_values,
+#   cmac.get_plot_values, cmac.get_zs_relationships
+#   cmac.cmac, cmac.quicklooks_ppi, cmac.quicklooks_rhi, cmac.tall_clutter
+#
+# Values defined here OVERRIDE the matching defaults in
+# cmac/default_config.py. Anything you do not list falls back to the
+# defaults, so you only need to specify what you want to change.
+#
+# Sections (all optional): metadata, field_names, cmac_values,
+# plot_values, zs_relationships.
+
+# --- Tweak an existing radar key (xsapr_i5_ppi) -----------------------------
+cmac_values:
+  xsapr_i5_ppi:
+    # Bump the reflectivity offset without re-stating the rest of the dict.
+    ref_offset: 1.5
+    zdr_offset: 2.8
+
+metadata:
+  xsapr_i5_ppi:
+    developers: "Your Name, Your Institution."
+
+# --- Add a brand-new radar key --------------------------------------------
+# A new radar key needs every section the downstream code reads. For cmac()
+# that is field_names + cmac_values + metadata; plot_values is only needed
+# if you call quicklooks_ppi / quicklooks_rhi for it.
+field_names:
+  my_radar_ppi:
+    input_zdr: differential_reflectivity
+    reflectivity: reflectivity
+    input_phidp_field: differential_phase
+    velocity: velocity
+    normalized_coherent_power: normalized_coherent_power
+    cross_correlation_ratio: cross_correlation_ratio
+    differential_reflectivity: differential_reflectivity
+    signal_to_noise_ratio: null
+    altitude: alt
+    temperature: tdry
+    u_wind: u_wind
+    v_wind: v_wind
+    zdr_field: corrected_differential_reflectivity
+    pia_field: path_integrated_attenuation
+    phidp_field: filtered_corrected_differential_phase
+    refl_field: corrected_reflectivity
+
+# Re-open cmac_values to add the new radar alongside the override above.
+# (YAML lets you merge two `cmac_values:` blocks by listing both radar keys
+# under one top-level entry — shown here as a single block for clarity.)
+#
+# cmac_values:
+#   my_radar_ppi:
+#     save_name: my_site_cmac.c1
+#     sonde_name: my_sonde.b1
+#     site_alt: 200
+#     ref_offset: 0.0
+#     self_const: 60000.0
+#     attenuation_a_coef: 0.17
+#     rain_rate_a_coef_A: 43.5
+#     rain_rate_b_coef_A: 0.79
+#     rain_rate_a_coef_Z: 0.029
+#     rain_rate_b_coef_Z: 0.67
+#     rain_rate_a_coef_Kdp: 16.9
+#     rain_rate_b_coef_Kdp: 0.801
+
+# --- Add or override a Z-S relationship -----------------------------------
+zs_relationships:
+  My Lab Relationship:
+    A: 95
+    B: 1.85
+    abbreviation: mylab

--- a/environment-3.6.yml
+++ b/environment-3.6.yml
@@ -10,6 +10,7 @@ dependencies:
   - cython=0.27
   - distributed
   - scikit-fuzzy
+  - pyyaml
   - pip
   - pip:
     - git+https://github.com/CSU-Radarmet/CSU_RadarTools.git

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - wradlib
   - numpy
   - matplotlib
+  - pyyaml
   - pip
   - pip:
     - git+https://github.com/CSU-Radarmet/CSU_RadarTools.git


### PR DESCRIPTION
This feature will add the capability for CMAC to use yaml files for all of the needed configuration parameters for each site. This eliminates the need to update the repo for every site and will make it much easier to operationalize for each new site.

This PR is generated with assistance from Claude Opus 4.7.