### PR TITLE
FIX: Do manylinux wheel builds for better PyPI compatbility.

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -5,8 +5,28 @@ on:
     types: [published]
 
 jobs:
-  build:
-    name: Build distribution
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    if: github.repository == 'ARM-Development/cmac'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: dist-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  build-sdist:
+    name: Build source distribution
     runs-on: ubuntu-latest
     if: github.repository == 'ARM-Development/cmac'
 
@@ -23,18 +43,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install build
 
-      - name: Build package
-        run: python -m build
+      - name: Build sdist
+        run: python -m build --sdist
 
-      - name: Store distribution packages
-        uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v6
         with:
-          name: python-package-distributions
-          path: dist/
+          name: dist-sdist
+          path: dist/*.tar.gz
 
   publish-to-pypi:
     name: Publish to PyPI
-    needs: build
+    needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -46,8 +65,9 @@ jobs:
       - name: Download distribution packages
         uses: actions/download-artifact@v8
         with:
-          name: python-package-distributions
+          pattern: dist-*
           path: dist/
+          merge-multiple: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "setuptools>=45",
     "wheel",
     "cython",
-    "oldest-supported-numpy; python_version<'3.9'",
     "numpy>=2.0; python_version>='3.9'",
 ]
 build-backend = "setuptools.build_meta"
@@ -30,3 +29,8 @@ test = [
 ext-modules = [
     { name = "cmac.calc_kdp_ray_fir", sources = ["cmac/calc_kdp_ray_fir.pyx"] }
 ]
+
+[tool.cibuildwheel]
+build = "cp310-* cp311-* cp312-* cp313-*"
+skip = "*-musllinux_i686 *-manylinux_i686 pp*"
+build-verbosity = 1


### PR DESCRIPTION
This is to make the GitHub Actions make a wheel that is compatible with PyPI while still compiling the cython code.

Created with assistance from Claude Opus 4.7.